### PR TITLE
Typo in TimeLine view configuration

### DIFF
--- a/_docs-v3/timeline-view/timeline-view.md
+++ b/_docs-v3/timeline-view/timeline-view.md
@@ -45,9 +45,9 @@ If you need a different duration, make a [custom view](custom-view-with-settings
 
 ```js
 $('#calendar').fullCalendar({
-  header: [
+  header: {
     center: 'month,timelineFourDays'
-  ],
+  },
   views: {
     timelineFourDays: {
       type: 'timeline',


### PR DESCRIPTION
Fix a typo in documentation : using `[ .. ]` instead of `{ .. }`