### PR TITLE
Made the CSS part in the setup docs more stand out

### DIFF
--- a/_docs-v3/intro/installation.md
+++ b/_docs-v3/intro/installation.md
@@ -43,17 +43,24 @@ import 'fullcalendar';
 
 Your import for `fullcalendar` does not need to be named. It will attached to jQuery as a plugin. [In the next section](initialization), you will learn how to use jQuery to initialize a calendar.
 
-You must also include FullCalendar's stylesheet somehow, some options:  
-Html link tag:  
+You must also include FullCalendar's stylesheet somehow, some options:
+
+Html link tag:
+
 ```html
 <link rel="stylesheet" type="text/css" href="./node_modules/fullcalendar/dist/fullcalendar.min.css">
-``` 
-Css import:  
+```
+
+Css import:
+
 ```css
 @import "./node_modules/fullcalendar/dist/fullcalendar.min.css";
 ```
-webpack [css-loader](https://github.com/webpack-contrib/css-loader) plugin:  
+
+webpack [css-loader](https://github.com/webpack-contrib/css-loader) plugin:
+
 ```js
 import "./node_modules/fullcalendar/dist/fullcalendar.min.css"
 ```
+
 *(the path names might be different)*

--- a/_docs-v3/intro/installation.md
+++ b/_docs-v3/intro/installation.md
@@ -46,13 +46,14 @@ Your import for `fullcalendar` does not need to be named. It will attached to jQ
 You must also include FullCalendar's stylesheet somehow, some options:  
 Html link tag:  
 ```html
-<link rel="stylesheet" type="text/css" href="~/node_modules/fullcalendar/dist/fullcalendar.min.css">
+<link rel="stylesheet" type="text/css" href="./node_modules/fullcalendar/dist/fullcalendar.min.css">
 ``` 
 Css import:  
 ```css
-@import "/node_modules/fullcalendar/dist/fullcalendar.min.css";
+@import "./node_modules/fullcalendar/dist/fullcalendar.min.css";
 ```
-webpack css-loader plugin:  
+webpack [css-loader](https://github.com/webpack-contrib/css-loader) plugin:  
 ```js
-import "/node_modules/fullcalendar/dist/fullcalendar.min.css"
+import "./node_modules/fullcalendar/dist/fullcalendar.min.css"
 ```
+*(the path names might be different on your project)*

--- a/_docs-v3/intro/installation.md
+++ b/_docs-v3/intro/installation.md
@@ -43,4 +43,16 @@ import 'fullcalendar';
 
 Your import for `fullcalendar` does not need to be named. It will attached to jQuery as a plugin. [In the next section](initialization), you will learn how to use jQuery to initialize a calendar.
 
-You must also include FullCalendar's stylesheet somehow, either manually with a `<link>` tag or via Webpack's [css-loader](https://github.com/webpack-contrib/css-loader).
+You must also include FullCalendar's stylesheet somehow, some options:  
+Html link tag:  
+```html
+<link rel="stylesheet" type="text/css" href="~/node_modules/fullcalendar/dist/fullcalendar.min.css">
+``` 
+Css import:  
+```css
+@import "/node_modules/fullcalendar/dist/fullcalendar.min.css";
+```
+webpack css-loader plugin:  
+```js
+import "/node_modules/fullcalendar/dist/fullcalendar.min.css"
+```

--- a/_docs-v3/intro/installation.md
+++ b/_docs-v3/intro/installation.md
@@ -56,4 +56,4 @@ webpack [css-loader](https://github.com/webpack-contrib/css-loader) plugin:
 ```js
 import "./node_modules/fullcalendar/dist/fullcalendar.min.css"
 ```
-*(the path names might be different on your project)*
+*(the path names might be different)*

--- a/_docs-v3/scheduler.md
+++ b/_docs-v3/scheduler.md
@@ -48,8 +48,19 @@ import 'fullcalendar';
 import 'fullcalendar-scheduler';
 ```
 
-You must also somehow include FullCalendar's `fullcalendar.css` and Scheduler's `scheduler.css`, either manually with a `<link>` tag or via Webpack's [css-loader](https://github.com/webpack-contrib/css-loader).
-
+You must also include FullCalendar's stylesheet somehow, some options:  
+Html link tag:  
+```html
+<link rel="stylesheet" type="text/css" href="/node_modules/fullcalendar-scheduler/dist/scheduler.min.css">
+``` 
+Css import:  
+```css
+@import "/node_modules/fullcalendar-scheduler/dist/scheduler.min.css";
+```
+webpack css-loader plugin:  
+```js
+import "/node_modules/fullcalendar-scheduler/dist/scheduler.min.css"
+```
 
 ## Initializing a View
 

--- a/_docs-v3/scheduler.md
+++ b/_docs-v3/scheduler.md
@@ -51,16 +51,17 @@ import 'fullcalendar-scheduler';
 You must also include FullCalendar's stylesheet somehow, some options:  
 Html link tag:  
 ```html
-<link rel="stylesheet" type="text/css" href="/node_modules/fullcalendar-scheduler/dist/scheduler.min.css">
+<link rel="stylesheet" type="text/css" href="./node_modules/fullcalendar-scheduler/dist/scheduler.min.css">
 ``` 
 Css import:  
 ```css
-@import "/node_modules/fullcalendar-scheduler/dist/scheduler.min.css";
+@import "./node_modules/fullcalendar-scheduler/dist/scheduler.min.css";
 ```
-webpack css-loader plugin:  
+webpack [css-loader](https://github.com/webpack-contrib/css-loader) plugin:  
 ```js
-import "/node_modules/fullcalendar-scheduler/dist/scheduler.min.css"
+import "./node_modules/fullcalendar-scheduler/dist/scheduler.min.css"
 ```
+*(the path names might be different)*
 
 ## Initializing a View
 

--- a/_docs-v3/scheduler.md
+++ b/_docs-v3/scheduler.md
@@ -12,7 +12,7 @@ The Scheduler plugin provides you with two extra calendar views to use, both of 
 - [Vertical Resource View](vertical-resource-view) - good at displaying a fewer number of resources
 
 Scheduler is a [premium plugin]({{ site.baseurl }}/scheduler) that has different licensing than the core FullCalendar library. [More information &raquo;]({{ site.baseurl }}/scheduler/license)
-
+/pull/38/pull/38
 
 ## Installation with Script Tags
 
@@ -48,19 +48,26 @@ import 'fullcalendar';
 import 'fullcalendar-scheduler';
 ```
 
-You must also include FullCalendar's stylesheet somehow, some options:  
-Html link tag:  
+You must also include FullCalendar's stylesheet somehow, some options:
+
+Html link tag:
+
 ```html
 <link rel="stylesheet" type="text/css" href="./node_modules/fullcalendar-scheduler/dist/scheduler.min.css">
-``` 
-Css import:  
+```
+
+Css import:
+
 ```css
 @import "./node_modules/fullcalendar-scheduler/dist/scheduler.min.css";
 ```
-webpack [css-loader](https://github.com/webpack-contrib/css-loader) plugin:  
+
+webpack [css-loader](https://github.com/webpack-contrib/css-loader) plugin:
+
 ```js
 import "./node_modules/fullcalendar-scheduler/dist/scheduler.min.css"
 ```
+
 *(the path names might be different)*
 
 ## Initializing a View


### PR DESCRIPTION
Because the CSS part in the setup docs doesn't stand out it's easy to read over it.  
After a view hours of debugging why the scheduler looked wrong and didn't work i finally out about the small sentence at the bottom.  

I think this is a better way to show a user he needs import this
