### PR TITLE
Fix eventDragStop and eventResizeStop docs: callback info is *before* changes

### DIFF
--- a/_docs-v4/event-dragging-resizing/eventDragStop.md
+++ b/_docs-v4/event-dragging-resizing/eventDragStop.md
@@ -18,7 +18,7 @@ This callback is *guaranteed* to be triggered after the user drags an event, eve
 <tr>
 <th>event</th>
 <td markdown='1'>
-An [Event Object](event-object) that holds information about the event (date, title, etc) **after** the drop.
+An [Event Object](event-object) that holds information about the event (date, title, etc) **before** the drop.
 </td>
 </tr>
 

--- a/_docs-v4/event-dragging-resizing/eventResizeStop.md
+++ b/_docs-v4/event-dragging-resizing/eventResizeStop.md
@@ -9,7 +9,7 @@ Triggered when event resizing stops.
 function( *info* ) { }
 </div>
 
-This callback is *guaranteed* to be triggered after the user resizes an event, even if the event doesn't change in duration. It is triggered before the event's information has been modified (if changed in duration) and before the [eventResize](eventResize) callback is triggered.
+This callback is *guaranteed* to be triggered after the user resizes an event, even if the event doesn't change in duration. It is triggered **before** the event's information has been modified (if changed in duration) and before the [eventResize](eventResize) callback is triggered.
 
 `info` is a plain object with the following properties:
 
@@ -18,7 +18,7 @@ This callback is *guaranteed* to be triggered after the user resizes an event, e
 <tr>
 <th>event</th>
 <td markdown='1'>
-An [Event Object](event-object) that holds information about the event (date, title, etc) **after** the drop.
+An [Event Object](event-object) that holds information about the event (date, title, etc) **before** the drop.
 </td>
 </tr>
 
@@ -37,3 +37,5 @@ The current [View Object](view-object).
 </tr>
 
 </table>
+
+If you want to get the event's information **after** it has changed, use the [eventResize](eventResize) callback.


### PR DESCRIPTION
The following screenshot shows the callback start/end dates, when I resized an event from 10am-11am to 10am-12:30pm.

![image](https://user-images.githubusercontent.com/398210/56141533-e4cdc580-5f94-11e9-829c-43ef5dbc4860.png)
