### PR TITLE
Event Source Object :: wrong signature for event function

### DIFF
--- a/_docs-v4/event-source/event-source-object.md
+++ b/_docs-v4/event-source/event-source-object.md
@@ -32,7 +32,7 @@ Event-generating function:
 
 ```js
 {
-  events: function(start, end, timezone, callback) {
+  events: function(info, successCallback, failureCallback) {
     // ...
   },
   color: 'yellow',   // an option!


### PR DESCRIPTION
Version 4.x of the docs uses the old version of the event function signature