### PR TITLE
[DA] iss-4982: document all dropinfo props. be consistent with param name

### DIFF
--- a/_docs-v4/event-dragging-resizing/eventAllow.md
+++ b/_docs-v4/event-dragging-resizing/eventAllow.md
@@ -13,9 +13,9 @@ After it has been determined that the [eventOverlap](eventOverlap) and [eventCon
 If specified, it must return either `true` or `false` as to whether the calendar will allow the given event (`draggedEvent`) to be dropped at the given location (`dropInfo`).
 
 ```js
-eventAllow: function(dropLocation, draggedEvent) {
+eventAllow: function(dropInfo, draggedEvent) {
   if (draggedEvent.id === '999') {
-    return dropLocation.start < new Date(2016, 0, 1); // a boolean
+    return dropInfo.start < new Date(2016, 0, 1); // a boolean
   }
   else {
     return true;
@@ -23,11 +23,53 @@ eventAllow: function(dropLocation, draggedEvent) {
 }
 ```
 
-The `dropLocation` object has the following properties:
+The `dropInfo` object has the following properties:
 
-- `start` (a [Date](date-object))
-- `end` (a [Date](date-object))
-- `resourceId` (if you are using a [Resource View](premium))
+<table>
+
+<tr>
+<th>allDay</th>
+<td markdown='1'>
+`true` or `false` whether the event was dropped on one of the all-day cells.
+</td>
+</tr>
+
+<tr>
+<th>end</th>
+<td markdown='1'>
+[Date](date-object). The end of where the draggable event was dropped.
+</td>
+</tr>
+
+<tr>
+<th>endStr</th>
+<td markdown='1'>
+The [ISO8601 string](https://en.wikipedia.org/wiki/ISO_8601) representation of the end of where the draggable event was dropped.
+</td>
+</tr>
+
+<tr>
+<th>resource</th>
+<td markdown='1'>
+If the current view is a resource-view, the [Resource Object](resource-object) the element was dropped on. This requires one of the [resource plugins](premium).
+</td>
+</tr>
+
+<tr>
+<th>start</th>
+<td markdown='1'>
+[Date](date-object). The beginning of where the draggable event was dropped.
+</td>
+</tr>
+
+<tr>
+<th>startStr</th>
+<td markdown='1'>
+The [ISO8601 string](https://en.wikipedia.org/wiki/ISO_8601) representation of the start of where the draggable event was dropped.
+</td>
+</tr>
+
+</table>
 
 In line with the discussion about the [Event object](event-parsing), it is important to stress that the `end` date property is **exclusive**.
 
@@ -37,8 +79,8 @@ In line with the discussion about the [Event object](event-parsing), it is impor
 In addition to receiving information about which date the user is attempting to drop the event upon, it will also receive information about the *resource*:
 
 ```js
-eventAllow: function(dropLocation, draggedEvent) {
-  return /^a/.test(dropLocation.resourceId); // starts with 'a' ?
+eventAllow: function(dropInfo, draggedEvent) {
+  return /^a/.test(dropInfo.resource.id); // starts with 'a' ?
 }
 ```
 


### PR DESCRIPTION
Issue: https://github.com/fullcalendar/fullcalendar/issues/4982