### PR TITLE
Removed doubled 'the'

### DIFF
--- a/_docs-v4/event-model/Calendar-addEvent.md
+++ b/_docs-v4/event-model/Calendar-addEvent.md
@@ -11,7 +11,7 @@ calendar.addEvent( *event* [, *source* ] )
 
 `event` is a plain object that will be [parsed into an Event Object](event-parsing).
 
-`source` represents the Event Source you want to associate this event with. It can be a string Event Source ID or an [Event Source Object](event-source-object). When the source is refetched, it will clear the the dynamically added event from the internal cache before fetching. This parameter is optional.
+`source` represents the Event Source you want to associate this event with. It can be a string Event Source ID or an [Event Source Object](event-source-object). When the source is refetched, it will clear the dynamically added event from the internal cache before fetching. This parameter is optional.
 
 This method returns the proper [Event Object](event-object) that was parsed from the plain object.
 


### PR DESCRIPTION
Just fixing a minor typo that I encountered while trying to understand Fullcalendar. Great work!