### PR TITLE
Added notes on RFC5545 compliance

### DIFF
--- a/_docs-v4/localization/firstDay.md
+++ b/_docs-v4/localization/firstDay.md
@@ -14,4 +14,5 @@ The value must be a number that represents the day of the week.
 
 Sunday=`0`, Monday=`1`, Tuesday=`2`, etc.
 
-If [weekNumberCalculation](weekNumberCalculation) is set to `'ISO'`, this option defaults to `1` (Monday).
+If [weekNumberCalculation](weekNumberCalculation) is set to `'ISO'`, this option defaults to `1` (Monday). (Note that RFC5545 follows the ISO standard as "\[t]he WKST rule part specifies the day on which the workweek starts \[and the] [default value is MO](https://tools.ietf.org/html/rfc5545#section-3.3.10)".
+


### PR DESCRIPTION
I think it is a good idea to always add a note when Fullcalender does not comply with what RFC5545 specifies for ICS.