### PR TITLE
Document correction : canlendar.formatIso method

### DIFF
--- a/_docs-v5/date-library/Calendar-formatIso.md
+++ b/_docs-v5/date-library/Calendar-formatIso.md
@@ -5,7 +5,7 @@ title: Calendar::formatIso
 Formats a date into an [ISO8601 string](https://en.wikipedia.org/wiki/ISO_8601). Outputs a UTC offset appropriate to the calendar it's called on.
 
 <div class='spec' markdown='1'>
-calendar.formateIso( *date*, [ *omitTime* = false ] )
+calendar.formatIso( *date*, [ *omitTime* = false ] )
 </div>
 
 `date` can be a [Date Object](date-object) or something that will [parse into a Date Object](date-parsing).


### PR DESCRIPTION
In the documentation, the method formatIso had a typo.