### PR TITLE
Minor type fix into fullcalendar locale page

### DIFF
--- a/_docs-v5/localization/locale.md
+++ b/_docs-v5/localization/locale.md
@@ -78,7 +78,7 @@ If you want to load ALL locales have the ability to switch between them after pa
 <script src='fullcalendar/core/locales-all.js'></script>
 <script>
 ...
-var calendar = new Calenar(calendarEl, {
+var calendar = new Calendar(calendarEl, {
   locale: 'es'
 });
 ...


### PR DESCRIPTION
There is an error in the page https://fullcalendar.io/docs/locale

![Capture d’écran de 2021-06-30 14-04-01](https://user-images.githubusercontent.com/25805069/123957416-0b2c7f80-d9ac-11eb-82c3-7ffbaad06e79.png)
