### PR TITLE
Fix link in custom-view-with-js.md

### DIFF
--- a/_docs-v5/custom-views/custom-view-with-js.md
+++ b/_docs-v5/custom-views/custom-view-with-js.md
@@ -97,7 +97,7 @@ If you're using the React connector you can [specify a React component instead](
 
 ## Props
 
-Both the config and component techniques receive "props", an object with information about the current view. You'll need to look at the [FullCalendar v5 source code](https://github.com/fullcalendar/fullcalendar/blob/master/packages/core/src/View.ts) to see exactly what's in `props`.
+Both the config and component techniques receive "props", an object with information about the current view. You'll need to look at the [FullCalendar v5 source code](https://github.com/fullcalendar/fullcalendar/blob/master/packages/common/src/View.ts) to see exactly what's in `props`.
 
 
 ## Other Considerations


### PR DESCRIPTION
This link is broken: FullCalendar v5 source code: https://github.com/fullcalendar/fullcalendar/blob/master/packages/core/src/View.ts
This one should be used instead: https://github.com/fullcalendar/fullcalendar/blob/master/packages/common/src/View.ts