### PR TITLE
Use correct keys for date-based start/end constraints

### DIFF
--- a/_docs-v5/event-dragging-resizing/eventConstraint.md
+++ b/_docs-v5/event-dragging-resizing/eventConstraint.md
@@ -29,8 +29,8 @@ A specific period of time with concrete start/end dates can also be given, simil
 
 ```js
 {
-  startTime: '2014-12-01T10:00:00',
-  endTime: '2014-12-05T22:00:00'
+  start: '2014-12-01T10:00:00',
+  end: '2014-12-05T22:00:00'
 }
 ```
 


### PR DESCRIPTION
`startTime` and `endTime` only consider time, and adding dates to them will not work as shown. They are supposed to be `start` and `end` when a date is involved, as I have found.