### PR TITLE
Document 'date' alias for 'start' in event parsing

### DIFF
--- a/_docs-v6/event-model/event-parsing.md
+++ b/_docs-v6/event-model/event-parsing.md
@@ -49,6 +49,8 @@ Here are all the available properties, **all of which are optional**:
   <th>start</th>
   <td markdown='1'>
   Something [date-parseable](date-parsing). When your event begins. If your event is explicitly `allDay`, hour, minutes, seconds and milliseconds will be ignored.
+
+  **Alias:** you can also use `date` instead of `start`. This is commonly used for simple one-day events.
   </td>
   </tr>
 


### PR DESCRIPTION
Clarified in the docs that `date` can be used as a shorthand for `start`. This avoids confusion for developers who see examples using `date` but can't find it documented. It also prevents duplicating content by documenting it as an alias instead of a separate property.