### PR TITLE
docs: add hover card / tooltip example to eventMouseEnter

### DIFF
--- a/_docs-v6/event-clicking-hovering/eventMouseEnter.md
+++ b/_docs-v6/event-clicking-hovering/eventMouseEnter.md
@@ -44,3 +44,89 @@ The current [View Object](view-object).
 </table>
 
 Unlike some other event-related interactions, `eventMouseEnter` does not require the `interaction` plugin.
+
+## Hover Card / Tooltip (no external library)
+
+Rather than reaching for a tooltip library — whose DOM attachment model often conflicts with FullCalendar's rendering cycle — you can build a dependency-free hover card using `eventMouseEnter`, `eventMouseLeave`, and a `position: fixed` element driven by `getBoundingClientRect()`.
+
+The key insight is a **short hide delay** (≈120 ms): this gives the cursor time to travel from the event pill to the card without the card disappearing mid-transit. Wiring `mouseenter`/`mouseleave` on the card itself cancels or restarts that timer.
+
+### Vanilla JS example
+
+```js
+let hoverEl = null;
+let hideTimer = null;
+
+function cancelHide() { clearTimeout(hideTimer); }
+function scheduleHide() { hideTimer = setTimeout(removeCard, 120); }
+
+function removeCard() {
+  if (hoverEl) { hoverEl.remove(); hoverEl = null; }
+}
+
+function showCard(event, rect) {
+  removeCard();
+  const CARD_W = 260;
+  const left = (rect.right + 8 + CARD_W > window.innerWidth)
+    ? rect.left - CARD_W - 8   // flip left if near right edge
+    : rect.right + 8;
+  const top = Math.max(8, Math.min(rect.top, window.innerHeight - 200 - 12));
+
+  hoverEl = document.createElement('div');
+  hoverEl.className = 'fc-hover-card';
+  hoverEl.style.cssText =
+    `position:fixed;left:${left}px;top:${top}px;width:${CARD_W}px;z-index:9999;` +
+    'background:#fff;border:1px solid #ddd;border-radius:8px;padding:12px;box-shadow:0 4px 20px rgba(0,0,0,.15)';
+  hoverEl.innerHTML = `<strong>${event.title}</strong><br>${event.startStr}`;
+  hoverEl.addEventListener('mouseenter', cancelHide);
+  hoverEl.addEventListener('mouseleave', scheduleHide);
+  document.body.appendChild(hoverEl);
+}
+
+var calendar = new Calendar(calendarEl, {
+  // ...
+  eventMouseEnter: function(info) {
+    cancelHide();
+    showCard(info.event, info.el.getBoundingClientRect());
+  },
+  eventMouseLeave: scheduleHide,
+});
+```
+
+### Viewport collision
+
+- **Horizontal**: if `rect.right + cardWidth > window.innerWidth`, render to the left of the event instead.
+- **Vertical**: clamp `top` to `window.innerHeight - cardHeight - 12` so the card never clips the bottom of the viewport.
+
+### React / Vue / Angular
+
+In component frameworks, replace the imperative DOM manipulation with state:
+
+```jsx
+// React (abbreviated)
+const [hoverCard, setHoverCard] = useState(null);
+const hideTimer = useRef(null);
+const cancelHide = () => clearTimeout(hideTimer.current);
+const scheduleHide = () => { hideTimer.current = setTimeout(() => setHoverCard(null), 120); };
+
+<FullCalendar
+  eventMouseEnter={(arg) => {
+    cancelHide();
+    const r = arg.el.getBoundingClientRect();
+    setHoverCard({ event: arg.event, x: r.right + 8, y: r.top });
+  }}
+  eventMouseLeave={scheduleHide}
+/>
+
+{hoverCard && (
+  <div
+    style={{ position: 'fixed', left: hoverCard.x, top: hoverCard.y, zIndex: 9999 }}
+    onMouseEnter={cancelHide}
+    onMouseLeave={scheduleHide}
+  >
+    <strong>{hoverCard.event.title}</strong>
+  </div>
+)}
+```
+
+This pattern requires no additional packages and works with any FullCalendar view.


### PR DESCRIPTION
Closes fullcalendar/fullcalendar#5517

## What this adds

A **Hover Card / Tooltip (no external library)** section to `eventMouseEnter.md` covering:

- Vanilla JS implementation using `getBoundingClientRect()` + `position: fixed`
- The **120 ms hide delay** pattern that lets the cursor travel from the event pill to the card without it disappearing mid-transit
- Viewport collision detection (horizontal flip + vertical clamp)
- Abbreviated React example using `useState` + `useRef` for the same pattern

## Why no library

Third-party tooltip libraries (Tooltip.js, Tippy.js) expect to own the DOM lifecycle of their anchor element. FullCalendar re-renders event elements on navigation, which breaks most library attachment strategies. The `position: fixed` + state approach sidesteps this entirely and has zero additional dependencies.

This pattern is running in production at [PostGlider](https://postglider.com), a social-media scheduling app built on Next.js + FullCalendar v6, across both month and week views.

## Related

- Supersedes the broken Tooltip.js demo referenced in fullcalendar/fullcalendar#5517
- No new dependencies introduced