### PR TITLE
Fix typo: Resoure Object -> Resource Object

### DIFF
--- a/_docs-v5/resource-display/resource-render-hooks.md
+++ b/_docs-v5/resource-display/resource-render-hooks.md
@@ -33,6 +33,6 @@ A resource "lane" is an element in resource-timeline view. It runs horizontally 
 
 When the above hooks are specified as a function in the form `function(arg)`, the `arg` is an object with the following properties:
 
-- `resource` - [Resoure Object](resource-object)
+- `resource` - [Resource Object](resource-object)
 - `date` - in vertical resource view, if this is a column that lives under a certain date, this will be the Date object
 - `el` - the label element. only available in `resourceLabelDidMount`, `resourceLabelWillUnmount`, `resourceLaneDidMount`, and `resourceLaneWillUnmount`

--- a/_docs-v6/resource-display/resource-render-hooks.md
+++ b/_docs-v6/resource-display/resource-render-hooks.md
@@ -33,6 +33,6 @@ A resource "lane" is an element in resource-timeline view. It runs horizontally 
 
 When the above hooks are specified as a function in the form `function(arg)`, the `arg` is an object with the following properties:
 
-- `resource` - [Resoure Object](resource-object)
+- `resource` - [Resource Object](resource-object)
 - `date` - in vertical resource view, if this is a column that lives under a certain date, this will be the Date object
 - `el` - the label element. only available in `resourceLabelDidMount`, `resourceLabelWillUnmount`, `resourceLaneDidMount`, and `resourceLaneWillUnmount`


### PR DESCRIPTION
## Summary
- Fixes the misspelled link text `Resoure Object` to `Resource Object` in the Resource Render Hooks docs Argument section (v5 and v6).

Fixes fullcalendar/fullcalendar#7554

## Test plan
- [x] Confirm the Argument section link text reads `Resource Object`
- [ ] Spot-check the rendered docs page after merge